### PR TITLE
Use react-0.14 findDOMNode() API

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var _objectWithoutProperties = function (obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; };
-
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
 var React = require('react');
+var ReactDOM = require('react-dom');
 var GeminiScrollbar = require('gemini-scrollbar');
 
 module.exports = React.createClass({
@@ -28,7 +29,7 @@ module.exports = React.createClass({
 
     componentDidMount: function componentDidMount() {
         this.scrollbar = new GeminiScrollbar({
-            element: this.getDOMNode(),
+            element: ReactDOM.findDOMNode(this),
             autoshow: this.props.autoshow,
             createElements: false
         }).create();

--- a/package.json
+++ b/package.json
@@ -23,9 +23,5 @@
   "homepage": "https://github.com/noeldelgado/react-gemini-scrollbar",
   "dependencies": {
     "gemini-scrollbar": "1.x.x"
-  },
-  "peerDependencies": {
-    "react": ">=0.14.0-rc",
-    "react-dom": ">=0.14.0-rc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gemini-scrollbar": "1.x.x"
   },
   "peerDependencies": {
-    "react": ">=0.12.0 || >=0.13.0-beta"
+    "react": ">=0.14.0-beta",
+    "react-dom": ">=0.14.0-beta"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gemini-scrollbar": "1.x.x"
   },
   "peerDependencies": {
-    "react": ">=0.14.0-beta",
-    "react-dom": ">=0.14.0-beta"
+    "react": ">=0.14.0-rc",
+    "react-dom": ">=0.14.0-rc"
   }
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,5 @@
 var React = require('react');
+var ReactDOM = require('react-dom');
 var GeminiScrollbar = require('gemini-scrollbar');
 
 module.exports = React.createClass({
@@ -22,7 +23,7 @@ module.exports = React.createClass({
 
     componentDidMount() {
         this.scrollbar = new GeminiScrollbar({
-            element: this.getDOMNode(),
+            element: ReactDOM.findDOMNode(this),
             autoshow: this.props.autoshow,
             createElements: false
         }).create();


### PR DESCRIPTION
Not sure how to put it well, so
here is an upgrade to make it work with react@0.14 beta (and the upcoming release, I guess).
It breaks the backwards compatibility, so the major version should be bumped I guess. Or maybe keep it beta for now - so I didn't touch the versioning thing.
Also I commit the dist folder - maybe it's kinda wrong.
