### PR TITLE
Add react 0.14 peer dependency back

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
   "homepage": "https://github.com/noeldelgado/react-gemini-scrollbar",
   "dependencies": {
     "gemini-scrollbar": "1.x.x"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   }
 }


### PR DESCRIPTION
My last accepted PR unfortunatelly lacked the peer dependency.
