### PR TITLE
null scrollbar fix for componentWillUnmount

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -43,7 +43,9 @@ module.exports = React.createClass({
     },
 
     componentWillUnmount: function componentWillUnmount() {
-        this.scrollbar.destroy();
+        if (this.scrollbar) {
+            this.scrollbar.destroy();
+        }
         this.scrollbar = null;
     },
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -37,7 +37,9 @@ module.exports = React.createClass({
     },
 
     componentWillUnmount() {
-        this.scrollbar.destroy();
+        if (this.scrollbar) {
+            this.scrollbar.destroy();
+        }
         this.scrollbar = null;
     },
 


### PR DESCRIPTION
In some cases, `componentWillUnmount` is called before `componentDidMount`, which leaves `this.scrollbar` as null and causes a `Cannot read property 'destroy' of null` error. [See this issue in React](https://github.com/facebook/react/issues/5719)
