### PR TITLE
Added Babel and friends to `devDependencies`, then rebuilt `dist/index.js`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react", "es2015", "stage-1"],
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -23,6 +23,7 @@ module.exports = React.createClass({
         };
     },
 
+
     /**
      * Holds the reference to the GeminiScrollbar instance.
      * @property scrollbar <public> [Object]
@@ -37,23 +38,22 @@ module.exports = React.createClass({
             createElements: false
         }).create();
     },
-
     componentDidUpdate: function componentDidUpdate() {
         this.scrollbar.update();
     },
-
     componentWillUnmount: function componentWillUnmount() {
         if (this.scrollbar) {
             this.scrollbar.destroy();
         }
         this.scrollbar = null;
     },
-
     render: function render() {
         var _props = this.props;
         var className = _props.className;
         var children = _props.children;
-        var other = _objectWithoutProperties(_props, ['className', 'children']);
+        var autoshow = _props.autoshow;
+        var forceGemini = _props.forceGemini;
+        var other = _objectWithoutProperties(_props, ['className', 'children', 'autoshow', 'forceGemini']);
         var classes = '';
 
         if (className) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React component for custom scrollbars with native scrolling",
   "main": "dist/index.js",
   "scripts": {
-    "dist": "mkdir -p dist && babel src/index.jsx -u -o dist/index.js --stage 1"
+    "dist": "mkdir -p dist && babel src/index.jsx -u -o dist/index.js"
   },
   "repository": {
     "type": "git",
@@ -27,5 +27,11 @@
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.10.1",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-react": "^6.11.1",
+    "babel-preset-stage-1": "^6.5.0"
   }
 }


### PR DESCRIPTION
As mentioned in #25, I thought I'd go ahead and rebuild `dist/index.js`.

I couldn't get `npm run dist` to run locally on my machine, so I added `babel-cli`, `babel-preset-es2015`, `babel-preset-react`, and `babel-preset-stage-1` to `devDependencies`, as well as a `.babelrc` file so that the npm script can call `babel` without needing any flags.

I assume your local babel setup was probably already using the React and ES2015 presets? It wouldn't build without them, and the diff doesn't show any new changes apart from the #26 fix.
