### PR TITLE
add context support

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,83 +1,130 @@
 'use strict';
 
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _geminiScrollbar = require('gemini-scrollbar');
+
+var _geminiScrollbar2 = _interopRequireDefault(_geminiScrollbar);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var React = require('react');
-var ReactDOM = require('react-dom');
-var GeminiScrollbar = require('gemini-scrollbar');
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-module.exports = React.createClass({
-    displayName: 'GeminiScrollbar',
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-    propTypes: {
-        autoshow: React.PropTypes.bool,
-        forceGemini: React.PropTypes.bool
-    },
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-    getDefaultProps: function getDefaultProps() {
-        return {
-            autoshow: false,
-            forceGemini: false
-        };
-    },
+var GeminiScrollbar = function (_Component) {
+  _inherits(GeminiScrollbar, _Component);
 
+  function GeminiScrollbar() {
+    var _Object$getPrototypeO;
+
+    var _temp, _this, _ret;
+
+    _classCallCheck(this, GeminiScrollbar);
+
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(GeminiScrollbar)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.scrollbar = null, _temp), _possibleConstructorReturn(_this, _ret);
+  }
+
+  _createClass(GeminiScrollbar, [{
+    key: 'getDefaultProps',
+    value: function getDefaultProps() {
+      return {
+        autoshow: false,
+        forceGemini: false
+      };
+    }
 
     /**
      * Holds the reference to the GeminiScrollbar instance.
      * @property scrollbar <public> [Object]
      */
-    scrollbar: null,
 
-    componentDidMount: function componentDidMount() {
-        this.scrollbar = new GeminiScrollbar({
-            element: ReactDOM.findDOMNode(this),
-            autoshow: this.props.autoshow,
-            forceGemini: this.props.forceGemini,
-            createElements: false
-        }).create();
-    },
-    componentDidUpdate: function componentDidUpdate() {
-        this.scrollbar.update();
-    },
-    componentWillUnmount: function componentWillUnmount() {
-        if (this.scrollbar) {
-            this.scrollbar.destroy();
-        }
-        this.scrollbar = null;
-    },
-    render: function render() {
-        var _props = this.props;
-        var className = _props.className;
-        var children = _props.children;
-        var autoshow = _props.autoshow;
-        var forceGemini = _props.forceGemini;
-        var other = _objectWithoutProperties(_props, ['className', 'children', 'autoshow', 'forceGemini']);
-        var classes = '';
-
-        if (className) {
-            classes += ' ' + className;
-        }
-
-        return React.createElement(
-            'div',
-            _extends({}, other, { className: classes }),
-            React.createElement(
-                'div',
-                { className: 'gm-scrollbar -vertical' },
-                React.createElement('div', { className: 'thumb' })
-            ),
-            React.createElement(
-                'div',
-                { className: 'gm-scrollbar -horizontal' },
-                React.createElement('div', { className: 'thumb' })
-            ),
-            React.createElement(
-                'div',
-                { className: 'gm-scroll-view', ref: 'scroll-view' },
-                children
-            )
-        );
+  }, {
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      console.log(this.refs.container);
+      this.scrollbar = new _geminiScrollbar2.default({
+        element: this.refs.container,
+        autoshow: this.props.autoshow,
+        forceGemini: this.props.forceGemini,
+        createElements: false
+      }).create();
     }
-});
+  }, {
+    key: 'componentDidUpdate',
+    value: function componentDidUpdate() {
+      this.scrollbar.update();
+    }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      if (this.scrollbar) {
+        this.scrollbar.destroy();
+      }
+      this.scrollbar = null;
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _props = this.props;
+      var className = _props.className;
+      var children = _props.children;
+      var autoshow = _props.autoshow;
+      var forceGemini = _props.forceGemini;
+
+      var other = _objectWithoutProperties(_props, ['className', 'children', 'autoshow', 'forceGemini']);
+
+      var classes = '';
+
+      if (className) {
+        classes += ' ' + className;
+      }
+
+      return _react2.default.createElement(
+        'div',
+        _extends({ className: classes, ref: 'container' }, other),
+        _react2.default.createElement(
+          'div',
+          { className: 'gm-scrollbar -vertical' },
+          _react2.default.createElement('div', { className: 'thumb' })
+        ),
+        _react2.default.createElement(
+          'div',
+          { className: 'gm-scrollbar -horizontal' },
+          _react2.default.createElement('div', { className: 'thumb' })
+        ),
+        _react2.default.createElement(
+          'div',
+          { className: 'gm-scroll-view', ref: 'scroll-view' },
+          children
+        )
+      );
+    }
+  }]);
+
+  return GeminiScrollbar;
+}(_react.Component);
+
+GeminiScrollbar.propTypes = {
+  autoshow: _react2.default.PropTypes.bool,
+  forceGemini: _react2.default.PropTypes.bool
+};
+exports.default = GeminiScrollbar;

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,6 +51,19 @@ var GeminiScrollbar = function (_Component) {
         forceGemini: false
       };
     }
+  }, {
+    key: 'getChildContext',
+    value: function getChildContext() {
+      var _this2 = this;
+
+      return {
+        geminiScrollbar: {
+          get: function get() {
+            return _this2.scrollbar;
+          }
+        }
+      };
+    }
 
     /**
      * Holds the reference to the GeminiScrollbar instance.
@@ -60,7 +73,6 @@ var GeminiScrollbar = function (_Component) {
   }, {
     key: 'componentDidMount',
     value: function componentDidMount() {
-      console.log(this.refs.container);
       this.scrollbar = new _geminiScrollbar2.default({
         element: this.refs.container,
         autoshow: this.props.autoshow,
@@ -126,5 +138,8 @@ var GeminiScrollbar = function (_Component) {
 GeminiScrollbar.propTypes = {
   autoshow: _react2.default.PropTypes.bool,
   forceGemini: _react2.default.PropTypes.bool
+};
+GeminiScrollbar.childContextTypes = {
+  geminiScrollbar: _react2.default.PropTypes.object
 };
 exports.default = GeminiScrollbar;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,12 +8,23 @@ export default class GeminiScrollbar extends Component {
     forceGemini: React.PropTypes.bool
   };
 
+  static childContextTypes = {
+    geminiScrollbar: React.PropTypes.object
+  };
+
   getDefaultProps() {
     return {
       autoshow: false,
       forceGemini: false
     };
   }
+
+  getChildContext() {
+    return {
+      geminiScrollbar: {
+        get: () => this.scrollbar
+      }
+    };
   }
 
   /**

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,68 +1,75 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var GeminiScrollbar = require('gemini-scrollbar');
 
-module.exports = React.createClass({
-    displayName: 'GeminiScrollbar',
+import React, { Component } from 'react';
+import Gemini from 'gemini-scrollbar';
 
-    propTypes: {
-        autoshow: React.PropTypes.bool,
-        forceGemini: React.PropTypes.bool
-    },
+export default class GeminiScrollbar extends Component {
+  static propTypes = {
+    autoshow: React.PropTypes.bool,
+    forceGemini: React.PropTypes.bool
+  };
 
-    getDefaultProps() {
-        return {
-            autoshow: false,
-            forceGemini: false
-        }
-    },
-
-    /**
-     * Holds the reference to the GeminiScrollbar instance.
-     * @property scrollbar <public> [Object]
-     */
-    scrollbar: null,
-
-    componentDidMount() {
-        this.scrollbar = new GeminiScrollbar({
-            element: ReactDOM.findDOMNode(this),
-            autoshow: this.props.autoshow,
-            forceGemini: this.props.forceGemini,
-            createElements: false
-        }).create();
-    },
-
-    componentDidUpdate() {
-        this.scrollbar.update();
-    },
-
-    componentWillUnmount() {
-        if (this.scrollbar) {
-            this.scrollbar.destroy();
-        }
-        this.scrollbar = null;
-    },
-
-    render() {
-        var {className, children, autoshow, forceGemini, ...other} = this.props,
-            classes = '';
-
-        if (className) {
-            classes += ' ' + className;
-        }
-
-        return (
-            <div {...other} className={classes}>
-                <div className='gm-scrollbar -vertical'>
-                    <div className='thumb'></div>
-                </div>
-                <div className='gm-scrollbar -horizontal'>
-                    <div className='thumb'></div>
-                </div>
-                <div className='gm-scroll-view' ref='scroll-view'>
-                    {children}
-                </div>
-            </div>
-        );
+  getDefaultProps() {
+    return {
+      autoshow: false,
+      forceGemini: false
     }
-});
+  }
+
+  /**
+   * Holds the reference to the GeminiScrollbar instance.
+   * @property scrollbar <public> [Object]
+   */
+  scrollbar = null;
+
+  componentDidMount() {
+    console.log(this.refs.container);
+    this.scrollbar = new Gemini({
+      element: this.refs.container,
+      autoshow: this.props.autoshow,
+      forceGemini: this.props.forceGemini,
+      createElements: false
+    }).create();
+  }
+
+  componentDidUpdate() {
+    this.scrollbar.update();
+  }
+
+  componentWillUnmount() {
+    if (this.scrollbar) {
+      this.scrollbar.destroy();
+    }
+    this.scrollbar = null;
+  }
+
+  render() {
+    const {
+      className,
+      children,
+      autoshow,
+      forceGemini,
+      ...other
+    } = this.props;
+
+    let classes = '';
+
+    if (className) {
+      classes += ` ${className}`;
+    }
+
+    return (
+      <div className={classes} ref="container" {...other} >
+        <div className="gm-scrollbar -vertical">
+          <div className="thumb"></div>
+        </div>
+        <div className="gm-scrollbar -horizontal">
+          <div className="thumb"></div>
+        </div>
+        <div className="gm-scroll-view" ref="scroll-view">
+          {children}
+        </div>
+      </div>
+    );
+  }
+}
+

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,7 +12,8 @@ export default class GeminiScrollbar extends Component {
     return {
       autoshow: false,
       forceGemini: false
-    }
+    };
+  }
   }
 
   /**
@@ -22,7 +23,6 @@ export default class GeminiScrollbar extends Component {
   scrollbar = null;
 
   componentDidMount() {
-    console.log(this.refs.container);
     this.scrollbar = new Gemini({
       element: this.refs.container,
       autoshow: this.props.autoshow,


### PR DESCRIPTION
I am using react-gemini-scrollbar library in my project and i find it very helpful. 

But today I was adding [react-scroll](https://github.com/fisshy/react-scroll) library which needs a _containerId_ - which can be obtained with scrollbar.getViewElement().

I added context support to the component, so now you can get the instance like this: 

```
class Button extends React.Component {
  static contextTypes = {
    geminiScrollbar: React.PropTypes.object
  };

  onClick() {
    console.log(this.context.geminiScrollbar.get().getViewElement);
  }
```

I also refactored the component as Class while doing that.
